### PR TITLE
Add support for JSON Schema Validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 1.1.0
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Master
+
+### Enhancements
+
+* Adds support for JSON Validators.
+
+
+## 1.0.0
+
+Initial Library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Adds support for JSON Validators.
 
+### Bug Fixes
+
+* Provides source map information on error annotations where possible.
+
 
 ## 1.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apiary-blueprint-parser",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Parser for Fury.js for the deprecated Apiary Blueprint language",
   "repository": {
     "type": "git",

--- a/src/parser.js
+++ b/src/parser.js
@@ -20,6 +20,13 @@ export default class Parser {
       annotation.classes.push('error');
       this.result.push(annotation);
 
+      if (err.offset) {
+        const {SourceMap} = this.minim.elements;
+        annotation.attributes.set('sourceMap', [
+          new SourceMap([[err.offset, 1]]),
+        ]);
+      }
+
       return done(err, this.result);
     }
 

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -71,7 +71,18 @@ Test Section 1
       meta: {
         classes: ['error'],
       },
-      attributes: {},
+      attributes: {
+        sourceMap: [
+          {
+            element: 'sourceMap',
+            meta: {},
+            attributes: {},
+            content: [
+              [78, 1],
+            ],
+          },
+        ],
+      },
       content: 'Expected "COPY", "DELETE", "GET", "HEAD", "LOCK", "MKCOL", "MOVE", "OPTIONS", "PATCH", "POST", "PROPPATCH", "PUT" or "UNLOCK" but end of input found.',
     };
 

--- a/test/fixtures/json-validations.json
+++ b/test/fixtures/json-validations.json
@@ -4,16 +4,6 @@
   "attributes": {},
   "content": [
     {
-      "element": "annotation",
-      "meta": {
-        "classes": [
-          "warning"
-        ]
-      },
-      "attributes": {},
-      "content": "The use of JSON Validations is not supported."
-    },
-    {
       "element": "category",
       "meta": {
         "classes": [
@@ -22,7 +12,483 @@
         "title": "API"
       },
       "attributes": {},
-      "content": []
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "title": "Example Resources",
+            "classes": [
+              "resourceGroup"
+            ]
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "resource",
+              "meta": {},
+              "attributes": {
+                "href": "/response-schema"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "GET"
+                  },
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "meta": {},
+                      "attributes": {},
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "meta": {},
+                          "attributes": {
+                            "method": "GET",
+                            "headers": null
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "meta": {},
+                          "attributes": {
+                            "statusCode": 200,
+                            "headers": {
+                              "element": "httpHeaders",
+                              "meta": {},
+                              "attributes": {},
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {},
+                              "content": "{ \"name\": \"Kyle\" }"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"type\": \"object\"\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "POST"
+                  },
+                  "attributes": {
+                    "href": "/implicit-request-schema"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "meta": {},
+                      "attributes": {},
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "meta": {},
+                          "attributes": {
+                            "method": "POST",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "meta": {},
+                              "attributes": {},
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {},
+                              "content": "{ \"name\": \"Kyle\" }"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{ \"type\": \"object\", \"required\": [\"name\"] }"
+                            }
+                          ]
+                        },
+                        {
+                          "element": "httpResponse",
+                          "meta": {},
+                          "attributes": {
+                            "statusCode": 201,
+                            "headers": {
+                              "element": "httpHeaders",
+                              "meta": {},
+                              "attributes": {},
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {},
+                              "content": "{ \"name\": \"Kyle\", \"url\": \"/me\" }"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "POST"
+                  },
+                  "attributes": {
+                    "href": "/request-response-schema"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "meta": {},
+                      "attributes": {},
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "meta": {},
+                          "attributes": {
+                            "method": "POST",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "meta": {},
+                              "attributes": {},
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {},
+                              "content": "{ \"name\": \"Kyle\" }"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"type\": \"object\"\n}"
+                            }
+                          ]
+                        },
+                        {
+                          "element": "httpResponse",
+                          "meta": {},
+                          "attributes": {
+                            "statusCode": 201,
+                            "headers": {
+                              "element": "httpHeaders",
+                              "meta": {},
+                              "attributes": {},
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {},
+                              "content": "{ \"name\": \"Kyle\", \"url\": \"/me\" }"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"type\": \"object\",\n  \"required\": [\n    \"url\"\n  ]\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "POST"
+                  },
+                  "attributes": {
+                    "href": "/invalid-schema"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "meta": {},
+                      "attributes": {},
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "meta": {},
+                          "attributes": {
+                            "method": "POST",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "meta": {},
+                              "attributes": {},
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {},
+                              "content": "{ \"name\": \"Kyle\" }"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{ \"Invalid JSON\" }"
+                            }
+                          ]
+                        },
+                        {
+                          "element": "httpResponse",
+                          "meta": {},
+                          "attributes": {
+                            "statusCode": 201,
+                            "headers": {
+                              "element": "httpHeaders",
+                              "meta": {},
+                              "attributes": {},
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {},
+                              "content": "{ \"name\": \"Kyle\", \"url\": \"/me\" }"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/json-validations.txt
+++ b/test/fixtures/json-validations.txt
@@ -1,5 +1,44 @@
 --- API ---
 
+--
+Example Resources
+--
+
+GET /response-schema
+< 200
+< Content-Type: application/json
+{ "name": "Kyle" }
+
+POST /implicit-request-schema
+> Content-Type: application/json
+{ "name": "Kyle" }
+< 201
+< Content-Type: application/json
+{ "name": "Kyle", "url": "/me" }
+
+POST /request-response-schema
+> Content-Type: application/json
+{ "name": "Kyle" }
+< 201
+< Content-Type: application/json
+{ "name": "Kyle", "url": "/me" }
+
+POST /invalid-schema
+> Content-Type: application/json
+{ "name": "Kyle" }
+< 201
+< Content-Type: application/json
+{ "name": "Kyle", "url": "/me" }
+
 -- JSON Schema Validations --
-GET /one
-{ "type": "object" }
+GET /response-schema
+{ "response": {"type": "object"} }
+
+POST /implicit-request-schema
+{ "type": "object", "required": ["name"] }
+
+POST /request-response-schema
+{ "request": {"type": "object"}, "response": {"type": "object", "required": ["url"]} }
+
+POST /invalid-schema
+{ "Invalid JSON" }


### PR DESCRIPTION
I manage to figure out how the JSON Schema Validations are supposed to work from some existing code:

- https://github.com/apiaryio/apiary_blueprint_convertor/blob/master/lib/apiary_blueprint_convertor/convertor.rb
- https://github.com/apiaryio/apiary_blueprint_convertor/blob/master/test/convertor_test.rb

This pull request implements the validations the same way as this existing code.