### PR TITLE
fix: Provide source maps for errors

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -20,6 +20,13 @@ export default class Parser {
       annotation.classes.push('error');
       this.result.push(annotation);
 
+      if (err.offset) {
+        const {SourceMap} = this.minim.elements;
+        annotation.attributes.set('sourceMap', [
+          new SourceMap([[err.offset, 1]]),
+        ]);
+      }
+
       return done(err, this.result);
     }
 

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -71,7 +71,18 @@ Test Section 1
       meta: {
         classes: ['error'],
       },
-      attributes: {},
+      attributes: {
+        sourceMap: [
+          {
+            element: 'sourceMap',
+            meta: {},
+            attributes: {},
+            content: [
+              [78, 1],
+            ],
+          },
+        ],
+      },
       content: 'Expected "COPY", "DELETE", "GET", "HEAD", "LOCK", "MKCOL", "MOVE", "OPTIONS", "PATCH", "POST", "PROPPATCH", "PUT" or "UNLOCK" but end of input found.',
     };
 


### PR DESCRIPTION
This is the only element that the Apiary Blueprint parser gives us source maps for.