### PR TITLE
Prevent duplicating HOST path in href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 1.1.1
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Master
+
+### Bug Fixes
+
+* Fixes a bug where a path included in the HOST metadata may be duplicated in
+  each href.
+
+
 ## 1.1.0
 
 ### Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apiary-blueprint-parser",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Parser for Fury.js for the deprecated Apiary Blueprint language",
   "repository": {
     "type": "git",

--- a/test/fixtures/host-path.json
+++ b/test/fixtures/host-path.json
@@ -1,0 +1,102 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "API"
+      },
+      "attributes": {
+        "meta": [
+          {
+            "element": "member",
+            "meta": {
+              "classes": [
+                "user"
+              ]
+            },
+            "attributes": {},
+            "content": {
+              "key": {
+                "element": "string",
+                "meta": {},
+                "attributes": {},
+                "content": "HOST"
+              },
+              "value": {
+                "element": "string",
+                "meta": {},
+                "attributes": {},
+                "content": "https://example.com/test"
+              }
+            }
+          }
+        ]
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "title": "Having a path in the HOST should not result in the transaction including the path.",
+            "classes": [
+              "resourceGroup"
+            ]
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "resource",
+              "meta": {},
+              "attributes": {
+                "href": "/message"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "GET"
+                  },
+                  "attributes": {
+                    "href": "/message"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "meta": {},
+                      "attributes": {},
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "meta": {},
+                          "attributes": {
+                            "method": "GET",
+                            "headers": null
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "meta": {},
+                          "attributes": {
+                            "statusCode": 204,
+                            "headers": null
+                          },
+                          "content": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/host-path.txt
+++ b/test/fixtures/host-path.txt
@@ -1,0 +1,9 @@
+HOST: https://example.com/test
+
+--- API ---
+--
+Having a path in the HOST should not result in the transaction including the path.
+--
+
+GET /message
+< 204


### PR DESCRIPTION
I noticed that the underlying parser will prepend a blueprint HOST's path into each url. This isn't the case in API Elements and would result in the path getting duplicated components when prepending it by the HOST.

This is equivalent to the logic found in metamorphosis: https://github.com/apiaryio/metamorphoses/blob/master/src/adapters/apiary-blueprint-adapter.coffee#L33