### PR TITLE
Prevent trimming leading slash on path from HOST metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 1.1.2
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Master
+
+### Bug Fixes
+
+* Fixes a bug where the leading slash on a path may be stripped if there is a
+  leading slash on a path in the HOST metadata.
+
+
 ## 1.1.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apiary-blueprint-parser",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Parser for Fury.js for the deprecated Apiary Blueprint language",
   "repository": {
     "type": "git",

--- a/src/parser.js
+++ b/src/parser.js
@@ -63,7 +63,13 @@ export default class Parser {
       const host = url.parse(this.blueprint.location);
 
       if (host.path && host.path !== '/' && path.startsWith(host.path)) {
-        return path.slice(host.path.length);
+        const newPath = path.slice(host.path.length);
+
+        if (!newPath.startsWith('/')) {
+          return '/' + newPath;
+        }
+
+        return newPath;
       }
     }
 

--- a/test/fixtures/host-trailing-slash-path.json
+++ b/test/fixtures/host-trailing-slash-path.json
@@ -1,0 +1,102 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "API"
+      },
+      "attributes": {
+        "meta": [
+          {
+            "element": "member",
+            "meta": {
+              "classes": [
+                "user"
+              ]
+            },
+            "attributes": {},
+            "content": {
+              "key": {
+                "element": "string",
+                "meta": {},
+                "attributes": {},
+                "content": "HOST"
+              },
+              "value": {
+                "element": "string",
+                "meta": {},
+                "attributes": {},
+                "content": "https://example.com/test/"
+              }
+            }
+          }
+        ]
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "title": "Having a path in the HOST should not result in the transaction including the path.",
+            "classes": [
+              "resourceGroup"
+            ]
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "resource",
+              "meta": {},
+              "attributes": {
+                "href": "/message"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "GET"
+                  },
+                  "attributes": {
+                    "href": "/message"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "meta": {},
+                      "attributes": {},
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "meta": {},
+                          "attributes": {
+                            "method": "GET",
+                            "headers": null
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "meta": {},
+                          "attributes": {
+                            "statusCode": 204,
+                            "headers": null
+                          },
+                          "content": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/host-trailing-slash-path.txt
+++ b/test/fixtures/host-trailing-slash-path.txt
@@ -1,0 +1,9 @@
+HOST: https://example.com/test/
+
+--- API ---
+--
+Having a path in the HOST should not result in the transaction including the path.
+--
+
+GET /message
+< 204


### PR DESCRIPTION
Fixes a bug where the leading slash on a path may be stripped if there is a leading slash on a path in the HOST metadata. This was a case I missed during https://github.com/apiaryio/fury-adapter-apiary-blueprint-parser/pull/4.