### PR TITLE
fix(schema): Ensure paths are stripped of the HOST path prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.3
+
+### Bug Fixes
+
+* Fixes a bug where having HOST metadata with a path would cause JSON Schema
+  Validations to not be converted to the API Elements result.
+
+
 ## 1.1.2
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apiary-blueprint-parser",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Parser for Fury.js for the deprecated Apiary Blueprint language",
   "repository": {
     "type": "git",

--- a/src/parser.js
+++ b/src/parser.js
@@ -118,7 +118,7 @@ export default class Parser {
     const transition = new Transition();
     transition.title = resource.method;
 
-    const schema = this.retrieveSchema(resource.method, resource.url);
+    const schema = this.retrieveSchema(resource.method, this.parseURL(resource.url));
 
     if (resource.description) {
       transition.push(new Copy(resource.description));

--- a/test/fixtures/json-validations-host-path.json
+++ b/test/fixtures/json-validations-host-path.json
@@ -1,0 +1,150 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "API"
+      },
+      "attributes": {
+        "meta": [
+          {
+            "element": "member",
+            "meta": {
+              "classes": [
+                "user"
+              ]
+            },
+            "attributes": {},
+            "content": {
+              "key": {
+                "element": "string",
+                "meta": {},
+                "attributes": {},
+                "content": "HOST"
+              },
+              "value": {
+                "element": "string",
+                "meta": {},
+                "attributes": {},
+                "content": "https://example.com/path/"
+              }
+            }
+          }
+        ]
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "title": "Example Resources",
+            "classes": [
+              "resourceGroup"
+            ]
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "resource",
+              "meta": {},
+              "attributes": {
+                "href": "/response-schema"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "GET"
+                  },
+                  "attributes": {
+                    "href": "/response-schema"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "meta": {},
+                      "attributes": {},
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "meta": {},
+                          "attributes": {
+                            "method": "GET",
+                            "headers": null
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "meta": {},
+                          "attributes": {
+                            "statusCode": 200,
+                            "headers": {
+                              "element": "httpHeaders",
+                              "meta": {},
+                              "attributes": {},
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "meta": {},
+                                      "attributes": {},
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {},
+                              "content": "{ \"name\": \"Kyle\" }"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"type\": \"object\"\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/json-validations-host-path.txt
+++ b/test/fixtures/json-validations-host-path.txt
@@ -1,0 +1,16 @@
+HOST: https://example.com/path/
+
+--- API ---
+
+--
+Example Resources
+--
+
+GET /response-schema
+< 200
+< Content-Type: application/json
+{ "name": "Kyle" }
+
+-- JSON Schema Validations --
+GET /response-schema
+{ "response": {"type": "object"} }


### PR DESCRIPTION
I've discovered that an actions url contains the HOST path's prefix, however the JSON Schema Validators path doesn't have the HOST path prefix.

Given the test fixture, the HOST path is `/path` and the resource path is `/response-schema` so the action path would become `/path/response-schema` but the JSON Schema Validator in the AST is still `/response-schema`. This means that the comparison for `/path/response-schema === /response-schema ` fails and thus the resulted API Elements would have no schemas. I've changed the code so that we remove the path before checking the schema.